### PR TITLE
Update CSF3 config to use new AMD nodes

### DIFF
--- a/manchester-CSF3.yaml
+++ b/manchester-CSF3.yaml
@@ -13,9 +13,9 @@ config:
       parallel_environments:
         null:
           num_cores: [1, 1, 1]
+        amd.pe:
+          num_cores: [2, 1, 168]
+          num_nodes: [1, 1, 1]
         smp.pe:
           num_cores: [2, 1, 32]
           num_nodes: [1, 1, 1]
-        mpi-24-ib.pe:
-          num_cores: [48, 24, 120]
-          num_nodes: [2, 1, 5]


### PR DESCRIPTION
smp.pe left in, because this is needed to target high-memory nodes.

Fix #1 